### PR TITLE
change default negotiate flags based on proxy server testing

### DIFF
--- a/negotiate_message.go
+++ b/negotiate_message.go
@@ -23,7 +23,9 @@ var defaultFlags = negotiateFlagNTLMSSPNEGOTIATETARGETINFO |
 	negotiateFlagNTLMSSPNEGOTIATE56 |
 	negotiateFlagNTLMSSPNEGOTIATE128 |
 	negotiateFlagNTLMSSPNEGOTIATEUNICODE |
-	negotiateFlagNTLMSSPNEGOTIATEEXTENDEDSESSIONSECURITY
+	negotiateFlagNTLMSSPNEGOTIATEEXTENDEDSESSIONSECURITY |
+	negotiateFlagNTLMSSPNEGOTIATENTLM |
+	negotiateFlagNTLMSSPNEGOTIATEALWAYSSIGN
 
 //NewNegotiateMessage creates a new NEGOTIATE message with the
 //flags that this package supports.


### PR DESCRIPTION
Background:

After numerous attempts to use the original `go-ntlmssp` package (in combination with [`go-ntlm-proxy-auth`](https://github.com/Codehardt/go-ntlm-proxy-auth) to talk to an NTLM-enabled proxy server (specifically WinGate 9.4), I was never able to get past the initial "negotiate" (a.k.a. "type 1") message; WinGate's error message was simply "invalid flags".

However, the Windows version of `curl` was able to connect successfully to WinGate with NTLM. Inspecting the traffic showed that `curl` was sending two flags that this Go code was not sending. Also, after looking at three or four other open-source NTLM packages for other platforms, it seems like all implementations _except_ the Azure one use those same flags.

I wish I could say I knew why. The `negotiateFlagNTLMSSPNEGOTIATENTLM` flag (called `NTLMSSP_NEGOTIATE_NTLM` in the [Microsoft docs](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-nlmp/99d90ff4-957f-4c8a-80e4-5bfe5a9a9832), or "Negotiate NTLM2 Key" in [these other docs](http://davenport.sourceforge.net/ntlm.html#ntlmVersion2)) is described completely differently in those two sources, and I see no clue as to why it would be mandatory.

The other one, `negotiateFlagNTLMSSPNEGOTIATEALWAYSSIGN` or `NTLMSSP_NEGOTIATE_ALWAYS_SIGN`, turns one security mechanism _off_ (the name is misleading; it really means "always pretend you signed"), which seems perhaps undesirable, but 1. it really looks like everyone else is doing it, and 2. inside a private network (which is the use case we've been looking at) perhaps it doesn't matter? I would very much like to understand this better, but information has been hard to find.