### PR TITLE
add go.mod, build as module in Go 1.13+

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,4 +96,5 @@ jobs:
           name: build and test
           command: |
             cd ${env:GOPATH}\src\${env:PACKAGE_PATH}
+            go get -t .
             go test -v -race ./...

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
           COMMON_GO_PACKAGES: >
             github.com/jstemmer/go-junit-report
 
-    working_directory: /go/src/github.com/launchdarkly/go-test-helpers
+    working_directory: /go/src/github.com/launchdarkly/go-ntlmssp
 
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,9 +9,11 @@ workflows:
       - go-test:
           name: Go 1.14
           docker-image: circleci/golang:1.14
+          build-as-module: true
       - go-test:
           name: Go 1.13
           docker-image: circleci/golang:1.13
+          build-as-module: true
       - go-test:
           name: Go 1.12
           docker-image: circleci/golang:1.12
@@ -35,6 +37,9 @@ jobs:
     parameters:
       docker-image:
         type: string
+      build-as-module:
+        type: boolean
+        default: false
 
     docker:
       - image: <<parameters.docker-image>>
@@ -49,7 +54,11 @@ jobs:
     steps:
       - checkout
       - run: go get -u $COMMON_GO_PACKAGES
-      - run: go get -t .
+
+      - unless:
+          condition: <<parameters.build-as-module>>
+          steps:
+            - run: go get -t .
       
       - run:
           name: Run tests
@@ -87,5 +96,4 @@ jobs:
           name: build and test
           command: |
             cd ${env:GOPATH}\src\${env:PACKAGE_PATH}
-            go get -t .
             go test -v -race ./...

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/launchdarkly/go-ntlmssp
+
+go 1.13
+
+require golang.org/x/crypto v0.0.0-20200604202706-70a84ac30bf9

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,7 @@
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20200604202706-70a84ac30bf9 h1:vEg9joUBmeBcK9iSJftGNf3coIG4HqZElCPehJsfAYM=
+golang.org/x/crypto v0.0.0-20200604202706-70a84ac30bf9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
Since the major version is still 1, building and consuming it as a module doesn't require any changes to the import path. Therefore, it  doesn't affect any consumers who are using dep or govendor. It just means that it's easier to pin the version of this dependency in a module-based project.